### PR TITLE
better logging when zero tuning parameters

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -86,18 +86,18 @@ recheck_options <- function(opts, .fn) {
 }
 
 
-check_fn <- function(fn, x) {
+check_fn <- function(fn, x, verbose) {
    has_tune <- nrow(tune::tune_args(x)) > 0
    if (!has_tune & fn != "fit_resamples") {
       fn <- "fit_resamples"
-      cols <- tune::get_tune_colors()
-      msg <- "No tuning parameters. `fit_resamples()` will be attempted"
-      message(cols$symbol$info("i"), "\t", cols$message$info(msg))
+      if (verbose) {
+         cols <- tune::get_tune_colors()
+         msg <- "No tuning parameters. `fit_resamples()` will be attempted"
+         message(cols$symbol$info("i"), "\t", cols$message$info(msg))
+      }
    }
    fn
 }
-
-
 
 check_names <- function(x) {
    nms <- names(x)

--- a/R/workflow_map.R
+++ b/R/workflow_map.R
@@ -27,7 +27,7 @@
 #'
 #' In cases where a model has no tuning parameters is mapped to one of the
 #' tuning functions, [tune::fit_resamples()] will be used instead and a
-#' warning is issued.
+#' warning is issued if `verbose = TRUE`.
 #'
 #' @examples
 #'
@@ -71,13 +71,13 @@ workflow_map <- function(object, fn = "tune_grid", verbose = FALSE,
    # new fingerprinting option.
 
    for (iter in iter_seq) {
-      log_progress(verbose, object$wflow_id[[iter]], NULL, iter_chr[iter],
-                   n, fn, NULL)
-
       wflow <- pull_workflow(object, object$wflow_id[[iter]])
 
-      .fn <- check_fn(fn, wflow)
+      .fn <- check_fn(fn, wflow, verbose)
       .fn_info <- dplyr::filter(allowed_fn, func == .fn)
+
+      log_progress(verbose, object$wflow_id[[iter]], NULL, iter_chr[iter],
+                   n, .fn, NULL)
 
       opt <- recheck_options(object$option[[iter]], .fn)
       run_time <- system.time({
@@ -89,7 +89,7 @@ workflow_map <- function(object, fn = "tune_grid", verbose = FALSE,
       })
       object <- new_workflow_set(object)
       log_progress(verbose, object$wflow_id[[iter]], object$result[[iter]],
-                   iter_chr[iter], n, fn, run_time)
+                   iter_chr[iter], n, .fn, run_time)
    }
    on.exit(return(new_workflow_set(object)))
 }

--- a/man/workflow_map.Rd
+++ b/man/workflow_map.Rd
@@ -47,7 +47,7 @@ contain a \code{try-error} object.
 
 In cases where a model has no tuning parameters is mapped to one of the
 tuning functions, \code{\link[tune:fit_resamples]{tune::fit_resamples()}} will be used instead and a
-warning is issued.
+warning is issued if \code{verbose = TRUE}.
 }
 \examples{
 

--- a/tests/testthat/_snaps/workflow-map.md
+++ b/tests/testthat/_snaps/workflow-map.md
@@ -3,9 +3,9 @@
     Code
       cat(logging_res, sep = "\n")
     Output
-      i 1 of 3 tuning:     reg_lm
       i	No tuning parameters. `fit_resamples()` will be attempted
+      i 1 of 3 resampling: reg_lm
       i 2 of 3 tuning:     reg_knn
-      i 3 of 3 tuning:     nonlin_lm
       i	No tuning parameters. `fit_resamples()` will be attempted
+      i 3 of 3 resampling: nonlin_lm
 

--- a/tests/testthat/test-workflow-map.R
+++ b/tests/testthat/test-workflow-map.R
@@ -24,34 +24,20 @@ car_set_1 <-
 # ------------------------------------------------------------------------------
 
 test_that("basic mapping", {
-   expect_message(
-      expect_message({
-         expect_error({
-            res_1 <-
-               car_set_1 %>%
-               workflow_map(resamples = folds, seed = 2, grid = 2)
-         },
-         regexp = NA)
-      },
-      "No tuning parameters"
-      ),
-      "No tuning parameters"
-   )
+   expect_error({
+      res_1 <-
+         car_set_1 %>%
+         workflow_map(resamples = folds, seed = 2, grid = 2)
+   },
+   regexp = NA)
 
    # check reproducibility
-   expect_message(
-      expect_message({
-         expect_error({
-            res_2 <-
-               car_set_1 %>%
-               workflow_map(resamples = folds, seed = 2, grid = 2)
-         },
-         regexp = NA)
-      },
-      "No tuning parameters"
-      ),
-      "No tuning parameters"
-   )
+   expect_error({
+      res_2 <-
+         car_set_1 %>%
+         workflow_map(resamples = folds, seed = 2, grid = 2)
+   },
+   regexp = NA)
    expect_equal(collect_metrics(res_1), collect_metrics(res_2))
 
    # ---------------------------------------------------------------------------


### PR DESCRIPTION
When `tune_grid` is used in `workflow_map()`, it reports a warning when there are no tuning parameters. 

This PR changes this so that: 

 * No warning issued unless `verbose = TRUE` is used. 
 * After the warning, the true function being called is annotated in the logging. 

Old logging:

```
i  1 of 12 tuning:     simple_MARS
✓  1 of 12 tuning:     simple_MARS (14.4s)
i  2 of 12 tuning:     simple_CART
✓  2 of 12 tuning:     simple_CART (58.6s)
i	No tuning parameters. `fit_resamples()` will be attempted
i  3 of 12 tuning:     simple_CART (bagged)
✓  3 of 12 tuning:     simple_CART (bagged) (1m 16.7s)
```

New logging: 

```
i  1 of 12 tuning:     simple_MARS
✓  1 of 12 tuning:     simple_MARS (14.4s)
i  2 of 12 tuning:     simple_CART
✓  2 of 12 tuning:     simple_CART (58.6s)
i	No tuning parameters. `fit_resamples()` will be attempted
i  3 of 12 resampling: simple_CART (bagged)
✓  3 of 12 resampling: simple_CART (bagged) (1m 16.7s)
```