### PR TITLE
Don't use a fixed string to test against workflows errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # workflowsets (development version)
 
+* Updated tests related to changes in workflows 0.2.5 (#75).
+
 * `as_workflow_set()` can now take a mixture of workflows or `tune_results` objects. 
 
 # workflowsets 0.1.0

--- a/tests/testthat/_snaps/extract.md
+++ b/tests/testthat/_snaps/extract.md
@@ -1,0 +1,14 @@
+# extracts
+
+    Code
+      car_set_1 %>% extract_workflow_set_result("Gideon Nav")
+    Error <rlang_error>
+      `id` must correspond to a single row in `x`.
+
+---
+
+    Code
+      car_set_1 %>% extract_workflow("Coronabeth Tridentarius")
+    Error <rlang_error>
+      `id` must correspond to a single row in `x`.
+

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -21,18 +21,12 @@ car_set_1 <-
 # ------------------------------------------------------------------------------
 
 test_that("extracts", {
-  expect_error(
-    extract_fit_engine(car_set_1, id = "reg_lm"),
-    "The workflow does not have a model fit"
-  )
-  expect_error(
-    extract_fit_parsnip(car_set_1, id = "reg_lm"),
-    "The workflow does not have a model fit"
-  )
-  expect_error(
-    extract_mold(car_set_1, id = "reg_lm"),
-    "workflow does not have a mold"
-  )
+  # workflows specific errors, so we don't capture their messages
+  expect_error(extract_fit_engine(car_set_1, id = "reg_lm"))
+  expect_error(extract_fit_parsnip(car_set_1, id = "reg_lm"))
+  expect_error(extract_mold(car_set_1, id = "reg_lm"))
+  expect_error(extract_recipe(car_set_1, id = "reg_lm"))
+
   expect_s3_class(
     extract_preprocessor(car_set_1, id = "reg_lm"),
     "recipe"
@@ -44,10 +38,6 @@ test_that("extracts", {
   expect_s3_class(
     extract_workflow(car_set_1, id = "reg_lm"),
     "workflow"
-  )
-  expect_error(
-    extract_recipe(car_set_1, id = "reg_lm"),
-    "workflow does not have a mold"
   )
   expect_s3_class(
     extract_recipe(car_set_1, id = "reg_lm", estimated = FALSE),
@@ -64,13 +54,11 @@ test_that("extracts", {
     car_set_1$result[[1]]
   )
 
-  expect_error(
-    car_set_1 %>% extract_workflow_set_result("Gideon Nav"),
-    "`id` must correspond to a single row in `x`"
-  )
+  expect_snapshot(error = TRUE, {
+     car_set_1 %>% extract_workflow_set_result("Gideon Nav")
+  })
 
-  expect_error(
-    car_set_1 %>% extract_workflow("Coronabeth Tridentarius"),
-    "`id` must correspond to a single row in `x`"
-  )
+  expect_snapshot(error = TRUE, {
+     car_set_1 %>% extract_workflow("Coronabeth Tridentarius")
+  })
 })


### PR DESCRIPTION
Since workflowsets doesn't own these error messages