### PR TITLE
use main parsnip ref for `Remotes`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,7 @@ Suggests:
     yardstick (>= 0.0.9.9000)
 Remotes:
     tidymodels/hardhat,
-    tidymodels/parsnip@feature/case-weights,
+    tidymodels/parsnip,
     tidymodels/recipes,
     tidymodels/tune,
     tidymodels/workflows,


### PR DESCRIPTION
Currently seeing:

```
pkgs <- c("hardhat", "parsnip", "recipes",
          "modeldata", "tune", "workflows", "yardstick")
pkgs <- paste0("tidymodels/", pkgs)
pak::pak(pkgs)
#> Error: Cannot install packages:                                                  
#> * tidymodels/tune: Can't install dependency tidymodels/parsnip@feature/case-weights
#> * tidymodels/parsnip@feature/case-weights: Conflicts with tidymodels/parsnip
```