### PR TITLE
return updated parameter set when possible in `extract_parameter_*` methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,15 @@
 
 To be released as workflowsets 1.0.1.
 
+* The `extract_parameter_dials()` and `extract_parameter_set_dials()` extractors
+  will now return the parameter or parameter set 
+  _that will be used by the tuning function utilized in `workflow_map()`_. 
+  The extractors previously always returned the parameter or parameter set
+  associated with the workflow contained in the `info` column, which can be
+  overridden by passing a `param_info` argument to `option_add()`. The 
+  extractors will now first look to the added options before extracting from
+  workflows.
+
 # workflowsets 1.0.0
 
 * New `extract_parameter_set_dials()` and `extract_parameter_dials()` methods to 

--- a/R/extract.R
+++ b/R/extract.R
@@ -29,6 +29,20 @@
 #' - `extract_workflow()` returns the workflow object. The workflow will not
 #'    have been estimated.
 #'
+#' - `extract_parameter_set_dials()` returns the parameter set
+#'   _that will be used to fit_ the supplied row `id` of the workflow set.
+#'   Note that workflow sets reference a parameter set associated with the
+#'   `workflow` contained in the `info` column by default, but can be
+#'   fitted with a modified parameter set via the [option_add()] interface.
+#'   This extractor returns the latter, if it exists, and returns the former
+#'   if not, mirroring the process that [workflow_map()] follows to provide
+#'   tuning functions a parameter set.
+#'
+#' - `extract_parameter_dials()` returns the `parameters` object
+#'    _that will be used to fit_ the supplied tuning `parameter` in the supplied
+#'   row `id` of the workflow set. See the above notes in
+#'   `extract_parameter_set_dials()` on precedence.
+#'
 #' @param x A workflow set.
 #' @param id A single character string for a workflow ID.
 #' @param parameter A single string for the parameter ID.
@@ -128,6 +142,11 @@ extract_preprocessor.workflow_set <- function(x, id, ...) {
 #' @rdname extract_workflow_set_result
 extract_parameter_set_dials.workflow_set <- function(x, id, ...) {
    y <- filter_id(x, id)
+
+   if ("param_info" %in% names(y$option[[1]])) {
+      return(y$option[[1]][["param_info"]])
+   }
+
    extract_parameter_set_dials(y$info[[1]]$workflow[[1]])
 }
 
@@ -135,6 +154,11 @@ extract_parameter_set_dials.workflow_set <- function(x, id, ...) {
 #' @rdname extract_workflow_set_result
 extract_parameter_dials.workflow_set <- function(x, id, parameter, ...) {
    y <- filter_id(x, id)
+
+   if ("param_info" %in% names(y$option[[1]])) {
+      return(extract_parameter_dials(y$option[[1]][["param_info"]], parameter))
+   }
+
    extract_parameter_dials(y$info[[1]]$workflow[[1]], parameter)
 }
 

--- a/R/extract.R
+++ b/R/extract.R
@@ -153,13 +153,10 @@ extract_parameter_set_dials.workflow_set <- function(x, id, ...) {
 #' @export
 #' @rdname extract_workflow_set_result
 extract_parameter_dials.workflow_set <- function(x, id, parameter, ...) {
-   y <- filter_id(x, id)
+   res <- extract_parameter_set_dials(x, id)
+   res <- extract_parameter_dials(res, parameter)
 
-   if ("param_info" %in% names(y$option[[1]])) {
-      return(extract_parameter_dials(y$option[[1]][["param_info"]], parameter))
-   }
-
-   extract_parameter_dials(y$info[[1]]$workflow[[1]], parameter)
+   res
 }
 
 # ------------------------------------------------------------------------------

--- a/man/extract_workflow_set_result.Rd
+++ b/man/extract_workflow_set_result.Rd
@@ -70,6 +70,18 @@ whether the fitted or original recipe is returned.
 for a particular workflow.
 \item \code{extract_workflow()} returns the workflow object. The workflow will not
 have been estimated.
+\item \code{extract_parameter_set_dials()} returns the parameter set
+\emph{that will be used to fit} the supplied row \code{id} of the workflow set.
+Note that workflow sets reference a parameter set associated with the
+\code{workflow} contained in the \code{info} column by default, but can be
+fitted with a modified parameter set via the \code{\link[=option_add]{option_add()}} interface.
+This extractor returns the latter, if it exists, and returns the former
+if not, mirroring the process that \code{\link[=workflow_map]{workflow_map()}} follows to provide
+tuning functions a parameter set.
+\item \code{extract_parameter_dials()} returns the \code{parameters} object
+\emph{that will be used to fit} the supplied tuning \code{parameter} in the supplied
+row \code{id} of the workflow set. See the above notes in
+\code{extract_parameter_set_dials()} on precedence.
 }
 }
 \details{

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -97,6 +97,10 @@ test_that("extract parameter set from workflow set with tunable workflow", {
    )
 
    c5_info <- extract_parameter_set_dials(wf_set, id = "reg_bst")
+   expect_equal(
+      c5_info,
+      extract_parameter_set_dials(bst_model)
+   )
    check_parameter_set_tibble(c5_info)
    expect_equal(nrow(c5_info), 2)
    expect_true(all(c5_info$source == "model_spec"))
@@ -109,6 +113,25 @@ test_that("extract parameter set from workflow set with tunable workflow", {
 
    expect_equal(c5_info$object[[1]], dials::trees(c(1, 100)))
    expect_equal(c5_info$object[[2]], NA)
+
+   c5_new_info <-
+      c5_info %>%
+      update(
+         rules = new_qual_param("logical",
+                                values = c(TRUE, FALSE),
+                                label = c(rules = "Rules"))
+      )
+
+   wf_set_2 <-
+      wf_set %>%
+      option_add(id = "reg_bst", param_info = c5_new_info)
+
+   check_parameter_set_tibble(c5_new_info)
+   expect_s3_class(c5_new_info$object[[2]], "qual_param")
+   expect_equal(
+      c5_new_info,
+      extract_parameter_set_dials(wf_set_2, "reg_bst")
+   )
 })
 
 

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -117,9 +117,9 @@ test_that("extract parameter set from workflow set with tunable workflow", {
    c5_new_info <-
       c5_info %>%
       update(
-         rules = new_qual_param("logical",
-                                values = c(TRUE, FALSE),
-                                label = c(rules = "Rules"))
+         rules = dials::new_qual_param("logical",
+                                       values = c(TRUE, FALSE),
+                                       label = c(rules = "Rules"))
       )
 
    wf_set_2 <-


### PR DESCRIPTION
Closes #102. 

The confusion underlying that issue arose from two interpretations of extracting information from a workflow set:

* _Current approach_: `wf_set %>% extract_parameter_set_dials(id = "boop_bop")` returns the parameter set from the workflow `"boop_bop"`, i.e. take `extract_parameter_set_dials(wf_set$info[[1]]$workflow[[1]])` even if the user has supplied an updated parameter set for that workflow via `option_add()`
* _Proposed approach_: `wf_set %>% extract_parameter_set_dials(id = "boop_bop")` returns the parameter set from the workflow set with workflow ID`"boop_bop"`, i.e. return whatever parameter set will be used / has been used to fit the workflow with ID `"boop_bop"` when fitting the workflow set via `workflow_map()`.

This PR takes the approach of changing the `extract_*` methods to use the latter interpretation, and is breaking. Another approach we could add here is to introduce an argument to the `extract` methods that determines which interpretation is used, though I still think we ought to default to the second (breaking) interpretation.