### PR TITLE
transition `pull_*()` deprecations from `soft` to `warn`

### DIFF
--- a/R/pull.R
+++ b/R/pull.R
@@ -25,7 +25,7 @@
 #' pull_workflow(two_class_res, "none_cart")
 #' @export
 pull_workflow_set_result <- function(x, id) {
-  lifecycle::deprecate_soft(
+  lifecycle::deprecate_warn(
     "0.1.0",
     "pull_workflow_set_result()",
     "extract_workflow_set_result()"
@@ -43,7 +43,7 @@ pull_workflow_set_result <- function(x, id) {
 #' @export
 #' @rdname pull_workflow_set_result
 pull_workflow <- function(x, id) {
-  lifecycle::deprecate_soft("0.1.0", "pull_workflow()", "extract_workflow()")
+  lifecycle::deprecate_warn("0.1.0", "pull_workflow()", "extract_workflow()")
   if (length(id) != 1) {
     rlang::abort("'id' should have a single value.")
   }


### PR DESCRIPTION
Closes #116.🪐