### PR TITLE
introduce support for tidyclust

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,6 +52,7 @@ Suggests:
     rmarkdown,
     spelling,
     testthat (>= 3.0.0),
+    tidyclust,
     yardstick (>= 1.0.0)
 VignetteBuilder: 
     knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@ To be released as workflowsets 1.0.1.
   overridden by passing a `param_info` argument to `option_add()`. The 
   extractors will now first look to the added options before extracting from
   workflows.
+* Introduces support for clustering model specifications via the tidyclust 
+  package. Supplying clustering models to `workflow_set()` and set
+  `fn = "tune_cluster"` in `workflow_map()` to use this feature!
 
 # workflowsets 1.0.0
 

--- a/R/checks.R
+++ b/R/checks.R
@@ -102,7 +102,7 @@ recheck_options <- function(opts, .fn) {
 
 check_fn <- function(fn, x, verbose) {
   has_tune <- nrow(tune::tune_args(x)) > 0
-  if (!has_tune & fn != "fit_resamples") {
+  if (!has_tune & !fn %in% c("fit_resamples", "tune_cluster")) {
     fn <- "fit_resamples"
     if (verbose) {
       cols <- tune::get_tune_colors()

--- a/R/workflow_map.R
+++ b/R/workflow_map.R
@@ -218,7 +218,9 @@ allowed_fn_list <- paste0("'", allowed_fn$func, "'", collapse = ", ")
 
 # ---------------------------------------------
 check_object_fn <- function(object, fn, call = rlang::caller_env()) {
-   wf_specs <- purrr::map(object$wflow_id, ~extract_spec_parsnip(object, id = .x))
+   wf_specs <- purrr::map(
+     object$wflow_id, ~extract_spec_parsnip(object, id = .x)
+   )
    is_cluster_spec <- purrr::map_lgl(wf_specs, inherits, "cluster_spec")
 
    if (identical(fn, "tune_cluster")) {
@@ -243,9 +245,10 @@ check_object_fn <- function(object, fn, call = rlang::caller_env()) {
    if (any(is_cluster_spec)) {
       msg <- c(
          msg,
-         "i" = "{cli::qty(object$wflow_id[is_cluster_spec])} The workflow{?/s} \\
-                {.var {object$wflow_id[is_cluster_spec]}} {?is a /are} cluster
-                specification{?/s}. Did you intend to set `fn = 'tune_cluster'`?"
+         "i" = "{cli::qty(object$wflow_id[is_cluster_spec])} \\
+                The workflow{?/s} {.var {object$wflow_id[is_cluster_spec]}} \\
+                {?is a /are} cluster specification{?/s}. Did you intend to \\
+                set `fn = 'tune_cluster'`?"
       )
    }
    if (!all(is_model_spec)) {

--- a/tests/testthat/_snaps/workflow-map.md
+++ b/tests/testthat/_snaps/workflow-map.md
@@ -3,7 +3,7 @@
     Code
       two_class_set %>% workflow_map("foo", seed = 1, resamples = folds, grid = 2)
     Error <rlang_error>
-      `fn` must be one of "tune_grid", "tune_bayes", "fit_resamples", "tune_race_anova", "tune_race_win_loss", or "tune_sim_anneal", not "foo".
+      `fn` must be one of "tune_grid", "tune_bayes", "fit_resamples", "tune_race_anova", "tune_race_win_loss", "tune_sim_anneal", or "tune_cluster", not "foo".
 
 ---
 
@@ -30,4 +30,34 @@
       i 2 of 3 tuning:     reg_knn
       i	No tuning parameters. `fit_resamples()` will be attempted
       i 3 of 3 resampling: nonlin_lm
+
+# fail informatively on mismatched spec/tuning function
+
+    Code
+      workflow_map(wf_set_1, resamples = folds)
+    Error <rlang_error>
+      To tune with `tune_grid()`, each workflow's model specification must inherit from <model_spec>, but `reg_km` does not.
+      i The workflow `reg_km` is a cluster specification. Did you intend to set `fn = 'tune_cluster'`?
+
+---
+
+    Code
+      workflow_map(wf_set_2, resamples = folds)
+    Error <rlang_error>
+      To tune with `tune_grid()`, each workflow's model specification must inherit from <model_spec>, but `reg_km` and `reg_hc` do not.
+      i The workflows `reg_km` and `reg_hc` are cluster specifications. Did you intend to set `fn = 'tune_cluster'`?
+
+---
+
+    Code
+      workflow_map(wf_set_1, resamples = folds, fn = "tune_cluster")
+    Error <rlang_error>
+      To tune with `tune_cluster()`, each workflow's model specification must inherit from <cluster_spec>, but `reg_dt` does not.
+
+---
+
+    Code
+      workflow_map(wf_set_3, resamples = folds, fn = "tune_cluster")
+    Error <rlang_error>
+      To tune with `tune_cluster()`, each workflow's model specification must inherit from <cluster_spec>, but `reg_dt` and `reg_nn` do not.
 

--- a/tests/testthat/test-workflow-map.R
+++ b/tests/testthat/test-workflow-map.R
@@ -152,9 +152,10 @@ test_that("workflow_map can handle cluster specifications", {
    skip_on_cran()
    skip_if_not_installed("tidyclust")
    library(tidyclust)
+   library(recipes)
 
    set.seed(1)
-   mtcars_tbl <- mtcars %>% select(where(is.numeric))
+   mtcars_tbl <- mtcars %>% dplyr::select(where(is.numeric))
    folds <- vfold_cv(mtcars_tbl, v = 3)
 
    wf_set_spec <-
@@ -175,7 +176,7 @@ test_that("fail informatively on mismatched spec/tuning function", {
    library(tidyclust)
 
    set.seed(1)
-   mtcars_tbl <- mtcars %>% select(where(is.numeric))
+   mtcars_tbl <- mtcars %>% dplyr::select(where(is.numeric))
    folds <- vfold_cv(mtcars_tbl, v = 3)
 
    wf_set_1 <-

--- a/tests/testthat/test-workflow-map.R
+++ b/tests/testthat/test-workflow-map.R
@@ -147,3 +147,76 @@ test_that("failers", {
   expect_true(inherits(res_loud, "workflow_set"))
   expect_true(inherits(res_loud$result[[1]], "try-error"))
 })
+
+test_that("workflow_map can handle cluster specifications", {
+   skip_on_cran()
+   skip_if_not_installed("tidyclust")
+   library(tidyclust)
+
+   set.seed(1)
+   mtcars_tbl <- mtcars %>% select(where(is.numeric))
+   folds <- vfold_cv(mtcars_tbl, v = 3)
+
+   wf_set_spec <-
+      workflow_set(
+         list(all = recipe(mtcars_tbl, ~ .), some = ~ mpg + hp),
+         list(km = k_means(num_clusters = tune()))
+      )
+
+   wf_set_fit <-
+      workflow_map(wf_set_spec, fn = "tune_cluster", resamples = folds)
+
+   wf_set_fit
+})
+
+test_that("fail informatively on mismatched spec/tuning function", {
+   skip_on_cran()
+   skip_if_not_installed("tidyclust")
+   library(tidyclust)
+
+   set.seed(1)
+   mtcars_tbl <- mtcars %>% select(where(is.numeric))
+   folds <- vfold_cv(mtcars_tbl, v = 3)
+
+   wf_set_1 <-
+      workflow_set(
+         list(reg = mpg ~ .),
+         list(dt = decision_tree("regression", min_n = tune()),
+              km = k_means(num_clusters = tune()))
+      )
+
+   wf_set_2 <-
+      workflow_set(
+         list(reg = mpg ~ .),
+         list(dt = decision_tree("regression", min_n = tune()),
+              km = k_means(num_clusters = tune()),
+              hc = hier_clust())
+      )
+
+   wf_set_3 <-
+      workflow_set(
+         list(reg = mpg ~ .),
+         list(dt = decision_tree("regression", min_n = tune()),
+              nn = nearest_neighbor("regression", neighbors = tune()),
+              km = k_means(num_clusters = tune()))
+      )
+
+   # pass a cluster spec to `tune_grid()`
+   expect_snapshot(error = TRUE,
+     workflow_map(wf_set_1, resamples = folds)
+   )
+
+   expect_snapshot(error = TRUE,
+     workflow_map(wf_set_2, resamples = folds)
+   )
+
+   # pass a model spec to `tune_cluster()`
+   expect_snapshot(error = TRUE,
+     workflow_map(wf_set_1, resamples = folds, fn = "tune_cluster")
+   )
+
+   expect_snapshot(error = TRUE,
+     workflow_map(wf_set_3, resamples = folds, fn = "tune_cluster")
+   )
+})
+


### PR DESCRIPTION
Closes #115!

* Adds `"tune_cluster"` as an accepted option to `workflow_map(fn)`
* Adds a helper to further check for compatibility between model specifications and tuning function. Otherwise, defers to checks from tuning functions and those that they call. The messages for supplying mismatched arguments are a bit different depending on context. In the cluster spec & `"tune_grid()"` case, we supply an extra note that folks can use `tune_cluster()` with workflowsets. 

A couple things worth noting:

* `tune_cluster()` plays the role of both `fit_resamples()` and `tune_*()` in tidyclust, correct? i.e. we only need to accept `tune_cluster()`?
* Is `"cluster_spec"` the class we want to check for, or `"unsupervised_spec"`?