### PR TITLE
add `type` argument to `autoplot.workflowset()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 * Added methods to improve error messages when workflow sets are mistakenly
   passed to unsupported functions like `fit()` and `predict()`.
+* Added a new argument, `type`, to the `workflow_set` `autoplot()` method. The
+  default, `"class"`, retains the existing behavior of mapping model type to 
+  color and preprocessor type to shape, while the new `"wflow_id"`
+  type maps the workflow IDs to color.
 
 # workflowsets 1.0.1
 

--- a/man/autoplot.workflow_set.Rd
+++ b/man/autoplot.workflow_set.Rd
@@ -11,6 +11,7 @@
   id = "workflow_set",
   select_best = FALSE,
   std_errs = qnorm(0.95),
+  type = "class",
   ...
 )
 }
@@ -34,6 +35,11 @@ best submodel per workflow?}
 
 \item{std_errs}{The number of standard errors to plot (if the standard error
 exists).}
+
+\item{type}{The aesthetics with which to differentiate workflows. The
+default \code{"class"} maps color to the model type and shape to the preprocessor
+type. The \code{"workflow"} option maps a color to each \code{"wflow_id"}. This
+argument is ignored for values of \code{id} other than \code{"workflow_set"}.}
 
 \item{...}{Other options to pass to \code{autoplot()}.}
 }

--- a/tests/testthat/_snaps/autoplot.md
+++ b/tests/testthat/_snaps/autoplot.md
@@ -1,0 +1,8 @@
+# autoplot with bad type input
+
+    Code
+      autoplot(two_class_res, metric = "roc_auc", type = "banana")
+    Condition
+      Error in `autoplot()`:
+      ! `type` must be one of "class" or "wflow_id", not "banana".
+

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -1,4 +1,4 @@
-test_that("autoplot with error bars", {
+test_that("autoplot with error bars (class)", {
   p_1 <- autoplot(two_class_res, metric = "roc_auc")
   expect_s3_class(p_1, "ggplot")
   expect_equal(
@@ -23,6 +23,39 @@ test_that("autoplot with error bars", {
   expect_equal(as.character(p_1$labels$y), "roc_auc")
   expect_equal(as.character(p_1$labels$x), "Workflow Rank")
 })
+
+test_that("autoplot with error bars (wflow_id)", {
+   p_1 <- autoplot(two_class_res, metric = "roc_auc", type = "wflow_id")
+   expect_s3_class(p_1, "ggplot")
+   expect_equal(
+      names(p_1$data),
+      c(
+         "wflow_id", ".config", ".metric", "mean", "std_err", "n",
+         "preprocessor", "model", "rank"
+      )
+   )
+   expect_equal(rlang::get_expr(p_1$mapping$x), expr(rank))
+   expect_equal(rlang::get_expr(p_1$mapping$y), expr(mean))
+   expect_equal(rlang::get_expr(p_1$mapping$colour), expr(wflow_id))
+   expect_equal(
+      rlang::get_expr(as.list(p_1$layers[[2]])$mapping$ymin),
+      expr(mean - std_errs * std_err)
+   )
+   expect_equal(
+      rlang::get_expr(as.list(p_1$layers[[2]])$mapping$ymax),
+      expr(mean + std_errs * std_err)
+   )
+   expect_equal(as.character(p_1$labels$y), "roc_auc")
+   expect_equal(as.character(p_1$labels$x), "Workflow Rank")
+})
+
+test_that("autoplot with bad type input", {
+  expect_snapshot(
+    error = TRUE,
+    autoplot(two_class_res, metric = "roc_auc", type = "banana")
+  )
+})
+
 
 test_that("autoplot with without error bars", {
   p_2 <- autoplot(chi_features_res)


### PR DESCRIPTION
Closes #114.

Unsure whether we should add an argument like this PR does or just change the default behavior. Also, I don't feel confident in the names of the argument values.🤔

``` r
library(tidymodels)

mt_rec <- recipe(mpg ~ ., mtcars)
mt_rec2 <- mt_rec %>% step_normalize(all_numeric_predictors())
mt_rec3 <- mt_rec %>% step_YeoJohnson(all_numeric_predictors())

wflow_set <-
   workflow_set(list(mt_rec, mt_rec2, mt_rec3), list(linear_reg()))

set.seed(1)
wflow_set_fit <- 
   workflow_map(
      wflow_set, 
      "fit_resamples", 
      resamples = bootstraps(mtcars), 
      seed = 1
   )

autoplot(wflow_set_fit, type = "wflow_id")
```

![](https://i.imgur.com/Pf72ToD.png)<!-- -->

<sup>Created on 2023-11-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>