### PR TITLE
allow passing `eval_time` through `workflow_map()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: workflowsets
 Title: Create a Collection of 'tidymodels' Workflows
-Version: 1.0.1.9000
+Version: 1.0.1.9001
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut"),
            comment = c(ORCID = "0000-0003-2402-136X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # workflowsets (development version)
 
+* Enabled evaluating censored regression models (#139).
 * Added a `collect_notes()` method for workflow sets (#135).
 * Added methods to improve error messages when workflow sets are mistakenly
   passed to unsupported functions like `fit()` and `predict()`.

--- a/R/checks.R
+++ b/R/checks.R
@@ -84,7 +84,7 @@ check_options <- function(model, id, global, action = "fail") {
 
 check_tune_args <- function(x) {
   arg_names <- c("resamples", "param_info", "grid", "metrics", "control",
-                 "iter", "objective", "initial")
+                 "iter", "objective", "initial", "eval_time")
   bad_args <- setdiff(x, arg_names)
   if (length(bad_args) > 0) {
      msg <- paste0("'", bad_args, "'")

--- a/R/checks.R
+++ b/R/checks.R
@@ -99,7 +99,7 @@ check_tune_args <- function(x) {
 
 recheck_options <- function(opts, .fn) {
   if (.fn == "fit_resamples") {
-    allowed <- c("object", "resamples", "metrics", "control")
+    allowed <- c("object", "resamples", "metrics", "control", "eval_time")
     nms <- names(opts)
     disallowed <- !(nms %in% allowed)
     if (any(disallowed)) {


### PR DESCRIPTION
Some refactoring that needs to happen here but this should be enough to open up workflowsets to survival.