### PR TITLE
support `eval_time` in `fit_best()` and `rank_results()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,6 +54,8 @@ Suggests:
     testthat (>= 3.0.0),
     tidyclust,
     yardstick (>= 1.3.0)
+Remotes:
+    tidymodels/tune
 VignetteBuilder: 
     knitr
 Config/Needs/website: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: workflowsets
 Title: Create a Collection of 'tidymodels' Workflows
-Version: 1.0.1.9001
+Version: 1.0.1.9002
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = c("aut"),
            comment = c(ORCID = "0000-0003-2402-136X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # workflowsets (development version)
 
-* Enabled evaluating censored regression models (#139).
+* Enabled evaluating censored regression models (#139, #144).
 * Added a `collect_notes()` method for workflow sets (#135).
 * Added methods to improve error messages when workflow sets are mistakenly
   passed to unsupported functions like `fit()` and `predict()` (#137).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # workflowsets (development version)
 
-* Enabled evaluating censored regression models (#139, #144).
+* Enabled evaluating censored regression models (#139, #144). The placement of 
+  the new `eval_time` argument to `rank_results()` breaks passing-by-position 
+  for the `select_best` argument.
 * Added a `collect_notes()` method for workflow sets (#135).
 * Added methods to improve error messages when workflow sets are mistakenly
   passed to unsupported functions like `fit()` and `predict()` (#137).

--- a/R/fit_best.R
+++ b/R/fit_best.R
@@ -76,24 +76,28 @@ fit_best.workflow_set <- function(x, metric = NULL, eval_time = NULL, ...) {
    check_string(metric, allow_null = TRUE)
    result_1 <- extract_workflow_set_result(x, id = x$wflow_id[[1]])
    met_set <- tune::.get_tune_metrics(result_1)
-   if (!is.null(metric)) {
-      tune::check_metric_in_tune_results(tibble::as_tibble(met_set), metric)
-   }
-   tune::check_eval_time_arg(eval_time, met_set)
 
    if (is.null(metric)) {
-      metric <- .get_tune_metric_names(result_1)[1]
+     metric <- .get_tune_metric_names(result_1)[1]
+   } else {
+     tune::check_metric_in_tune_results(tibble::as_tibble(met_set), metric)
    }
 
    if (is.null(eval_time) & is_dyn(met_set, metric)) {
      eval_time <- tune::.get_tune_eval_times(result_1)[1]
    }
 
-   rankings <- rank_results(x, rank_metric = metric, select_best = TRUE, eval_time = eval_time)
+   rankings <-
+      rank_results(
+        x,
+        rank_metric = metric,
+        select_best = TRUE,
+        eval_time = eval_time
+      )
 
    tune_res <- extract_workflow_set_result(x, id = rankings$wflow_id[1])
 
-   best_params <- select_best(tune_res, metric = metric)
+   best_params <- select_best(tune_res, metric = metric, eval_time = eval_time)
 
    fit_best(tune_res, metric = metric, parameters = best_params, ...)
 }

--- a/R/fit_best.R
+++ b/R/fit_best.R
@@ -99,7 +99,7 @@ fit_best.workflow_set <- function(x, metric = NULL, eval_time = NULL, ...) {
 
    best_params <- select_best(tune_res, metric = metric, eval_time = eval_time)
 
-   fit_best(tune_res, metric = metric, parameters = best_params, ...)
+   fit_best(tune_res, parameters = best_params, ...)
 }
 
 # from unexported

--- a/R/rank_results.R
+++ b/R/rank_results.R
@@ -6,6 +6,7 @@
 #' @param rank_metric A character string for a metric.
 #' @param select_best A logical giving whether the results should only contain
 #' the numerically best submodel per workflow.
+#' @inheritParams tune::fit_best.tune_results
 #' @details
 #' If some models have the exact same performance,
 #' `rank(value, ties.method = "random")` is used (with a reproducible seed) so

--- a/R/rank_results.R
+++ b/R/rank_results.R
@@ -4,9 +4,9 @@
 #'
 #' @inheritParams collect_metrics.workflow_set
 #' @param rank_metric A character string for a metric.
+#' @inheritParams tune::fit_best.tune_results
 #' @param select_best A logical giving whether the results should only contain
 #' the numerically best submodel per workflow.
-#' @inheritParams tune::fit_best.tune_results
 #' @details
 #' If some models have the exact same performance,
 #' `rank(value, ties.method = "random")` is used (with a reproducible seed) so
@@ -27,7 +27,7 @@
 #' rank_results(chi_features_res, select_best = TRUE)
 #' rank_results(chi_features_res, rank_metric = "rsq")
 #' @export
-rank_results <- function(x, rank_metric = NULL, select_best = FALSE, eval_time = NULL) {
+rank_results <- function(x, rank_metric = NULL, eval_time = NULL, select_best = FALSE) {
   check_wf_set(x)
   check_string(rank_metric, allow_null = TRUE)
   check_bool(select_best)

--- a/R/rank_results.R
+++ b/R/rank_results.R
@@ -36,7 +36,8 @@ rank_results <- function(x, rank_metric = NULL, select_best = FALSE, eval_time =
   if (!is.null(rank_metric)) {
     tune::check_metric_in_tune_results(tibble::as_tibble(met_set), rank_metric)
   }
-  tune::check_eval_time_arg(eval_time, met_set)
+
+  eval_time <- tune::choose_eval_time(result_1, rank_metric, eval_time)
 
   metric_info <- pick_metric(x, rank_metric)
   metric <- metric_info$metric
@@ -48,6 +49,10 @@ rank_results <- function(x, rank_metric = NULL, select_best = FALSE, eval_time =
                   dplyr::any_of(".eval_time")) %>%
     dplyr::full_join(wflow_info, by = "wflow_id") %>%
     dplyr::select(-comment, -workflow)
+
+  if (".eval_time" %in% names(results)) {
+    results <- results[results$.eval_time == eval_time, ]
+  }
 
   types <- x %>%
     dplyr::full_join(wflow_info, by = "wflow_id") %>%

--- a/man/fit_best.workflow_set.Rd
+++ b/man/fit_best.workflow_set.Rd
@@ -4,7 +4,7 @@
 \alias{fit_best.workflow_set}
 \title{Fit a model to the numerically optimal configuration}
 \usage{
-\method{fit_best}{workflow_set}(x, metric = NULL, ...)
+\method{fit_best}{workflow_set}(x, metric = NULL, eval_time = NULL, ...)
 }
 \arguments{
 \item{x}{A \code{\link[=workflow_set]{workflow_set}} object that has been evaluated

--- a/man/fit_best.workflow_set.Rd
+++ b/man/fit_best.workflow_set.Rd
@@ -13,6 +13,11 @@ the \link[=option_add]{control option} \code{save_workflow = TRUE}.}
 
 \item{metric}{A character string giving the metric to rank results by.}
 
+\item{eval_time}{A single numeric time point where dynamic event time
+metrics should be chosen (e.g., the time-dependent ROC curve, etc). The
+values should be consistent with the values used to create \code{x}. The \code{NULL}
+default will automatically use the first evaluation time used by \code{x}.}
+
 \item{...}{Additional options to pass to
 \link[tune:fit_best]{tune::fit_best}.}
 }

--- a/man/rank_results.Rd
+++ b/man/rank_results.Rd
@@ -4,7 +4,7 @@
 \alias{rank_results}
 \title{Rank the results by a metric}
 \usage{
-rank_results(x, rank_metric = NULL, select_best = FALSE)
+rank_results(x, rank_metric = NULL, select_best = FALSE, eval_time = NULL)
 }
 \arguments{
 \item{x}{A \code{\link[=workflow_set]{workflow_set}} object that has been evaluated

--- a/man/rank_results.Rd
+++ b/man/rank_results.Rd
@@ -4,7 +4,7 @@
 \alias{rank_results}
 \title{Rank the results by a metric}
 \usage{
-rank_results(x, rank_metric = NULL, select_best = FALSE, eval_time = NULL)
+rank_results(x, rank_metric = NULL, eval_time = NULL, select_best = FALSE)
 }
 \arguments{
 \item{x}{A \code{\link[=workflow_set]{workflow_set}} object that has been evaluated
@@ -12,13 +12,13 @@ with \code{\link[=workflow_map]{workflow_map()}}.}
 
 \item{rank_metric}{A character string for a metric.}
 
-\item{select_best}{A logical giving whether the results should only contain
-the numerically best submodel per workflow.}
-
 \item{eval_time}{A single numeric time point where dynamic event time
 metrics should be chosen (e.g., the time-dependent ROC curve, etc). The
 values should be consistent with the values used to create \code{x}. The \code{NULL}
 default will automatically use the first evaluation time used by \code{x}.}
+
+\item{select_best}{A logical giving whether the results should only contain
+the numerically best submodel per workflow.}
 }
 \value{
 A tibble with columns: \code{wflow_id}, \code{.config}, \code{.metric}, \code{mean},

--- a/man/rank_results.Rd
+++ b/man/rank_results.Rd
@@ -14,6 +14,11 @@ with \code{\link[=workflow_map]{workflow_map()}}.}
 
 \item{select_best}{A logical giving whether the results should only contain
 the numerically best submodel per workflow.}
+
+\item{eval_time}{A single numeric time point where dynamic event time
+metrics should be chosen (e.g., the time-dependent ROC curve, etc). The
+values should be consistent with the values used to create \code{x}. The \code{NULL}
+default will automatically use the first evaluation time used by \code{x}.}
 }
 \value{
 A tibble with columns: \code{wflow_id}, \code{.config}, \code{.metric}, \code{mean},

--- a/tests/testthat/_snaps/fit_best.md
+++ b/tests/testthat/_snaps/fit_best.md
@@ -11,8 +11,8 @@
     Code
       fit_best(chi_features_map, metric = "boop")
     Condition
-      Error in `halt()`:
-      ! Metric 'boop' was not in the results.
+      Error in `fit_best()`:
+      ! "boop" was not in the metric set. Please choose from: "rmse" and "rsq".
 
 ---
 


### PR DESCRIPTION
~An initial, incomplete go at introducing full support for survival in workflowsets. Still some more work to do and tests to add, though my COVID brain is tired, so I'm going to go nap.😴~

`fit_best.workflow_set()` handles `eval_time` as much like `fit_best.tune_results()` as it can, and the same goes for `rank_results()` and `select_best.tune_results()`.

Note that this PR will introduce a dev tune dependency. Related to #142.