### PR TITLE
Tweak docs for `option_add()`

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -11,7 +11,7 @@
 #'
 #' @export
 #' @inheritParams comment_add
-#' @param ... A list of named options to pass to the `tune_*()` functions (e.g.
+#' @param ... Arguments to pass to the `tune_*()` functions (e.g.
 #' [tune::tune_grid()]) or [tune::fit_resamples()]. For `option_remove()` this
 #' can be a series of unquoted option names.
 #' @param id A character string of one or more values from the `wflow_id`

--- a/man/option_add.Rd
+++ b/man/option_add.Rd
@@ -15,7 +15,7 @@ option_add_parameters(x, id = NULL, strict = FALSE)
 \arguments{
 \item{x}{A workflow set outputted by \code{\link[=workflow_set]{workflow_set()}} or \code{\link[=workflow_map]{workflow_map()}}.}
 
-\item{...}{A list of named options to pass to the \verb{tune_*()} functions (e.g.
+\item{...}{Arguments to pass to the \verb{tune_*()} functions (e.g.
 \code{\link[tune:tune_grid]{tune::tune_grid()}}) or \code{\link[tune:fit_resamples]{tune::fit_resamples()}}. For \code{option_remove()} this
 can be a series of unquoted option names.}
 


### PR DESCRIPTION
"a list" could be mistaken for "a `list()` but you just need to add the arguments as usual, see the examples.