### PR TITLE
require optional arguments to be named

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # workflowsets (development version)
 
+* Ellipses (...) are now used consistently in the package to require optional arguments to be named; `collect_metrics()` and `collect_predictions()` are the only functions that received changes (#151, tidymodels/tune#863).
 * Enabled evaluating censored regression models (#139, #144). The placement of 
   the new `eval_time` argument to `rank_results()` breaks passing-by-position 
   for the `select_best` argument.

--- a/R/collect.R
+++ b/R/collect.R
@@ -4,6 +4,7 @@
 #'
 #' @param x A [`workflow_set`][workflow_set()] object that has been evaluated
 #' with [workflow_map()].
+#' @param ... Not currently used.
 #' @param summarize A logical for whether the performance estimates should be
 #'  summarized via the mean (over resamples) or the raw performance values (per
 #'  resample) should be returned along with the resampling identifiers. When
@@ -17,7 +18,6 @@
 #' are retained. If `TRUE`, the `parameters` argument is ignored.
 #' @param metric A character string for the metric that is used for
 #' `select_best`.
-#' @param ... Not currently used.
 #' @return A tibble.
 #' @details
 #'
@@ -57,7 +57,8 @@
 #'
 #' collect_metrics(two_class_res, summarize = FALSE)
 #' @export
-collect_metrics.workflow_set <- function(x, summarize = TRUE, ...) {
+collect_metrics.workflow_set <- function(x, ..., summarize = TRUE) {
+  rlang::check_dots_empty()
   check_incompete(x, fail = TRUE)
   check_bool(summarize)
   x <-
@@ -98,8 +99,9 @@ reorder_cols <- function(x) {
 #' @export
 #' @rdname collect_metrics.workflow_set
 collect_predictions.workflow_set <-
-  function(x, summarize = TRUE, parameters = NULL, select_best = FALSE,
-           metric = NULL, ...) {
+  function(x, ..., summarize = TRUE, parameters = NULL, select_best = FALSE,
+           metric = NULL) {
+    rlang::check_dots_empty()
     check_incompete(x, fail = TRUE)
     check_bool(summarize)
     check_bool(select_best)

--- a/man/collect_metrics.workflow_set.Rd
+++ b/man/collect_metrics.workflow_set.Rd
@@ -6,15 +6,15 @@
 \alias{collect_notes.workflow_set}
 \title{Obtain and format results produced by tuning functions for workflow sets}
 \usage{
-\method{collect_metrics}{workflow_set}(x, summarize = TRUE, ...)
+\method{collect_metrics}{workflow_set}(x, ..., summarize = TRUE)
 
 \method{collect_predictions}{workflow_set}(
   x,
+  ...,
   summarize = TRUE,
   parameters = NULL,
   select_best = FALSE,
-  metric = NULL,
-  ...
+  metric = NULL
 )
 
 \method{collect_notes}{workflow_set}(x, ...)
@@ -23,13 +23,13 @@
 \item{x}{A \code{\link[=workflow_set]{workflow_set}} object that has been evaluated
 with \code{\link[=workflow_map]{workflow_map()}}.}
 
+\item{...}{Not currently used.}
+
 \item{summarize}{A logical for whether the performance estimates should be
 summarized via the mean (over resamples) or the raw performance values (per
 resample) should be returned along with the resampling identifiers. When
 collecting predictions, these are averaged if multiple assessment sets
 contain the same row.}
-
-\item{...}{Not currently used.}
 
 \item{parameters}{An optional tibble of tuning parameter values that can be
 used to filter the predicted values before processing. This tibble should


### PR DESCRIPTION
Thankfully not many changes needed here. :)

Did not move dots in `fit_best.workflow_set()`, `autoplot.workflow_set()`,`leave_var_out_formulas()`, `workflow_map()` since they're passed to downstream functions. Did not move in `comment_print()` for consistency with other `comment_*()` functions.

Follows up on tidymodels/tune#863.