### PR TITLE
Advance deprecation for `pull_*()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Added a `collect_extracts()` method for workflow sets (#156).
 
+* The deprecation of the `pull_*()` functions has been moved forward. These functions now error. Please use the `extract_*()` functions instead (#178).
+
 * Increased the minimum required R version to R 4.1.
 
 # workflowsets 1.1.0

--- a/R/pull.R
+++ b/R/pull.R
@@ -1,6 +1,6 @@
 #' Extract elements from a workflow set
 #'
-#' `r lifecycle::badge("soft-deprecated")`
+#' `r lifecycle::badge("deprecated")`
 #'
 #' `pull_workflow_set_result()` retrieves the results of [workflow_map()] for a
 #' particular workflow while `pull_workflow()` extracts the unfitted workflow
@@ -15,41 +15,17 @@
 #' @return `pull_workflow_set_result()` produces a `tune_result` or
 #' `resample_results` object. `pull_workflow()` returns an unfit workflow
 #' object.
-#' @examples
-#' library(tune)
-#'
-#' two_class_res
-#'
-#' pull_workflow_set_result(two_class_res, "none_cart")
-#'
-#' pull_workflow(two_class_res, "none_cart")
 #' @export
 pull_workflow_set_result <- function(x, id) {
-  lifecycle::deprecate_warn(
+  lifecycle::deprecate_stop(
     "0.1.0",
     "pull_workflow_set_result()",
     "extract_workflow_set_result()"
   )
-  if (length(id) != 1) {
-    cli::cli_abort("{.arg id} should have a single value.")
-  }
-  y <- x |> dplyr::filter(wflow_id == id[1])
-  if (nrow(y) != 1) {
-    cli::cli_abort("No workflow ID found for {.val {id[1]}}.")
-  }
-  y$result[[1]]
 }
 
 #' @export
 #' @rdname pull_workflow_set_result
 pull_workflow <- function(x, id) {
-  lifecycle::deprecate_warn("0.1.0", "pull_workflow()", "extract_workflow()")
-  if (length(id) != 1) {
-    cli::cli_abort("{.arg id} should have a single value.")
-  }
-  y <- x |> dplyr::filter(wflow_id == id[1])
-  if (nrow(y) != 1) {
-    cli::cli_abort("No workflow ID found for {.val {id[1]}}.")
-  }
-  y$info[[1]]$workflow[[1]]
+  lifecycle::deprecate_stop("0.1.0", "pull_workflow()", "extract_workflow()")
 }

--- a/man/pull_workflow_set_result.Rd
+++ b/man/pull_workflow_set_result.Rd
@@ -20,7 +20,7 @@ pull_workflow(x, id)
 object.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#soft-deprecated}{\figure{lifecycle-soft-deprecated.svg}{options: alt='[Soft-deprecated]'}}}{\strong{[Soft-deprecated]}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \details{
 \code{pull_workflow_set_result()} retrieves the results of \code{\link[=workflow_map]{workflow_map()}} for a
@@ -29,13 +29,4 @@ from the \code{info} column.
 
 The \code{\link[=extract_workflow_set_result]{extract_workflow_set_result()}} and \code{\link[=extract_workflow]{extract_workflow()}} functions should
 be used instead of these functions.
-}
-\examples{
-library(tune)
-
-two_class_res
-
-pull_workflow_set_result(two_class_res, "none_cart")
-
-pull_workflow(two_class_res, "none_cart")
 }

--- a/tests/testthat/_snaps/pull.md
+++ b/tests/testthat/_snaps/pull.md
@@ -1,40 +1,18 @@
-# pulling objects
+# pulling objects is deprecated
 
     Code
-      res <- pull_workflow(car_set_1, "reg_lm")
+      pull_workflow_set_result(car_set_1, "reg_lm")
     Condition
-      Warning:
-      `pull_workflow()` was deprecated in workflowsets 0.1.0.
-      i Please use `extract_workflow()` instead.
-
----
-
-    Code
-      res <- pull_workflow_set_result(car_set_1, "reg_lm")
-    Condition
-      Warning:
-      `pull_workflow_set_result()` was deprecated in workflowsets 0.1.0.
+      Error:
+      ! `pull_workflow_set_result()` was deprecated in workflowsets 0.1.0 and is now defunct.
       i Please use `extract_workflow_set_result()` instead.
 
 ---
 
     Code
-      pull_workflow_set_result(car_set_1, "Gideon Nav")
+      pull_workflow(car_set_1, "reg_lm")
     Condition
-      Warning:
-      `pull_workflow_set_result()` was deprecated in workflowsets 0.1.0.
-      i Please use `extract_workflow_set_result()` instead.
-      Error in `pull_workflow_set_result()`:
-      ! No workflow ID found for "Gideon Nav".
-
----
-
-    Code
-      pull_workflow(car_set_1, "Coronabeth Tridentarius")
-    Condition
-      Warning:
-      `pull_workflow()` was deprecated in workflowsets 0.1.0.
+      Error:
+      ! `pull_workflow()` was deprecated in workflowsets 0.1.0 and is now defunct.
       i Please use `extract_workflow()` instead.
-      Error in `pull_workflow()`:
-      ! No workflow ID found for "Coronabeth Tridentarius".
 

--- a/tests/testthat/test-pull.R
+++ b/tests/testthat/test-pull.R
@@ -17,19 +17,13 @@ car_set_1 <-
 
 # ------------------------------------------------------------------------------
 
-test_that("pulling objects", {
-  expect_snapshot(res <- car_set_1 |> pull_workflow("reg_lm"))
-  expect_equal(res, car_set_1$info[[1]]$workflow[[1]])
-
-  expect_snapshot(res <- car_set_1 |> pull_workflow_set_result("reg_lm"))
-  expect_equal(res, car_set_1$result[[1]])
-
+test_that("pulling objects is deprecated", {
   expect_snapshot(
     error = TRUE,
-    car_set_1 |> pull_workflow_set_result("Gideon Nav")
+    car_set_1 |> pull_workflow_set_result("reg_lm")
   )
   expect_snapshot(
     error = TRUE,
-    car_set_1 |> pull_workflow("Coronabeth Tridentarius")
+    car_set_1 |> pull_workflow("reg_lm")
   )
 })


### PR DESCRIPTION
closes #169

IIRC this is an item on the release checklist so I'm going to close this issue with this PR already.